### PR TITLE
feat: clue scroll timer update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# Example
-An example greeter plugin
+# Clue Juggling Timer
+
+Timers for dropped clues.

--- a/build.gradle
+++ b/build.gradle
@@ -10,23 +10,23 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.18.2'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
-group = 'com.example'
-version = '1.0.2'
-sourceCompatibility = '1.8'
+group = 'com.cluejuggling'
+version = '2.0.0'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+    options.release.set(11)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'clue-juggling-timers'

--- a/src/main/java/com/cluejuggling/ClueScrollJugglingConfig.java
+++ b/src/main/java/com/cluejuggling/ClueScrollJugglingConfig.java
@@ -5,7 +5,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("cluescrolljuggling")
-public interface ClueScrollJugginglingConfig extends Config
+public interface ClueScrollJugglingConfig extends Config
 {
 	@ConfigItem(
 		keyName = "notificationTime",

--- a/src/main/java/com/cluejuggling/ClueScrollJugglingPlugin.java
+++ b/src/main/java/com/cluejuggling/ClueScrollJugglingPlugin.java
@@ -1,7 +1,16 @@
 package com.cluejuggling;
 
 import com.google.inject.Provides;
+import java.awt.Color;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import javax.inject.Inject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -21,16 +30,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.ui.overlay.infobox.Timer;
 
-import javax.inject.Inject;
-import java.awt.*;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 @PluginDescriptor(
 	name = "Clue Juggling Timers",
 	description = "clue despawn timers",
@@ -46,7 +45,7 @@ public class ClueScrollJugglingPlugin extends Plugin
 	ItemManager itemManager;
 
 	@Inject
-	private ClueScrollJugginglingConfig config;
+	private ClueScrollJugglingConfig config;
 
 	@Inject
 	private InfoBoxManager infoBoxManager;
@@ -66,8 +65,8 @@ public class ClueScrollJugglingPlugin extends Plugin
 	private Set<GroundItem.GroundItemKey> alreadyNotified = new HashSet<>();
 
 	@Provides
-	public ClueScrollJugginglingConfig getConfig(ConfigManager configManager) {
-		return configManager.getConfig(ClueScrollJugginglingConfig.class);
+	public ClueScrollJugglingConfig getConfig(ConfigManager configManager) {
+		return configManager.getConfig(ClueScrollJugglingConfig.class);
 	}
 
 	@Subscribe
@@ -93,6 +92,14 @@ public class ClueScrollJugglingPlugin extends Plugin
 						? Color.RED
 						: super.getTextColor();
 				}
+
+                @Override
+                public String getText() {
+                    long remainingMinutes = Duration.between(Instant.now(), this.getEndTime()).toMinutes();
+                    return remainingMinutes >= 10
+                        ? String.format("%dm", remainingMinutes)
+                        : super.getText();
+                }
 			};
 			infoBoxManager.addInfoBox(timer);
 			alreadyNotified.remove(groundItemKey);
@@ -160,7 +167,7 @@ public class ClueScrollJugglingPlugin extends Plugin
 		MASTER(config -> config.masterTimers())
 		;
 
-		private final Predicate<ClueScrollJugginglingConfig> showTimer;
+		private final Predicate<ClueScrollJugglingConfig> showTimer;
 
 		public static ClueTier getClueTier(String clueName)
 		{
@@ -175,7 +182,7 @@ public class ClueScrollJugglingPlugin extends Plugin
 				;
 		}
 
-		public boolean showTimers(ClueScrollJugginglingConfig config)
+		public boolean showTimers(ClueScrollJugglingConfig config)
 		{
 			return showTimer.test(config);
 		}

--- a/src/main/java/com/cluejuggling/GroundItem.java
+++ b/src/main/java/com/cluejuggling/GroundItem.java
@@ -24,14 +24,13 @@
  */
 package com.cluejuggling;
 
+import java.time.Instant;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.time.Instant;
 
 @Data
 @Builder

--- a/src/main/java/com/cluejuggling/GroundItemPluginStuff.java
+++ b/src/main/java/com/cluejuggling/GroundItemPluginStuff.java
@@ -26,31 +26,31 @@
 package com.cluejuggling;
 
 import com.google.common.collect.EvictingQueue;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Queue;
+import javax.inject.Inject;
 import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.MenuAction;
 import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.eventbus.Subscribe;
-
-import javax.inject.Inject;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Queue;
 
 /**
  * Bunch of stuff I copied over from GroundItemsPlugin
  */
 public class GroundItemPluginStuff
 {
+    // Unsure if the changes to clues in:
+    // https://secure.runescape.com/m=news/miscellaneous-quality-of-life-changes?oldschool=1
+    // affects the despawn timer within instances (1 hr instead of 30 minutes)
+    // This entire file might need reworked/updated anyway
 	private static final Duration DESPAWN_TIME_INSTANCE = Duration.ofMinutes(30);
 	private static final Duration DESPAWN_TIME_LOOT = Duration.ofMinutes(2);
-	private static final Duration DESPAWN_TIME_DROP = Duration.ofMinutes(3);
+	private static final Duration DESPAWN_TIME_DROP = Duration.ofMinutes(60);
 	private static final Duration DESPAWN_TIME_TABLE = Duration.ofMinutes(10);
 	private static final int KRAKEN_REGION = 9116;
 	private static final int KBD_NMZ_REGION = 9033;
@@ -211,7 +211,7 @@ public class GroundItemPluginStuff
 			// item spawns that are drops
 			droppedItemQueue.add(itemId);
 		}
-		else if (menuOptionClicked.getMenuAction() == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT && plugin.client.getSelectedWidget().getId() == WidgetInfo.INVENTORY.getId())
+		else if (menuOptionClicked.getMenuAction() == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT && plugin.client.getSelectedWidget().getId() == ComponentID.INVENTORY_CONTAINER)
 		{
 			lastUsedItem = plugin.client.getSelectedWidget().getItemId();
 		}

--- a/src/test/java/com/cluejuggling/ClueScrollJugglingPluginTest.java
+++ b/src/test/java/com/cluejuggling/ClueScrollJugglingPluginTest.java
@@ -3,7 +3,7 @@ package com.cluejuggling;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
-public class ExamplePluginTest
+public class ClueScrollJugglingPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{


### PR DESCRIPTION
Jagex updated the clue despawn timer when dropped by the player from 3 minutes to 1 hour. Newspost link: https://secure.runescape.com/m=news/miscellaneous-quality-of-life-changes?oldschool=1

General plugin maintenance applied as well.

Fixes issue https://github.com/geheur/clue-juggling-timers/issues/2

BREAKING CHANGE: clue scroll drop timer increased from 3 minutes to 1 hour.